### PR TITLE
OH-515: YTJ-päivitys ei päivitä kaikkia tietoja oikein

### DIFF
--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioYtjServiceImpl.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioYtjServiceImpl.java
@@ -244,7 +244,7 @@ public class OrganisaatioYtjServiceImpl implements OrganisaatioYtjService {
             updateOsoite = updateOsoiteFromYTJToOrganisaatio(ytjOrg, osoite, forceUpdate);
         }
         if (validateYtjSahkoposti(ytjOrg)) {
-            Email email = organisaatio.getEmail();
+            Email email = organisaatio.getEmail(ytjKielikoodi);
             if (email == null) {
                 email = new Email();
                 if (!initYhteystietoforOrg(email, organisaatio, ytjKielikoodi, YtjVirhe.YTJVirheKohde.SAHKOPOSTI, "ilmoitukset.log.virhe.oid.sahkoposti")) {
@@ -254,7 +254,7 @@ public class OrganisaatioYtjServiceImpl implements OrganisaatioYtjService {
             updateSahkoposti = updateSahkopostiFromYTJToOrganisation(ytjOrg, email, forceUpdate);
         }
         if(validateYtjPuhelin(ytjOrg)) {
-            Puhelinnumero puhelinnumero = organisaatio.getPuhelin(Puhelinnumero.TYYPPI_PUHELIN);
+            Puhelinnumero puhelinnumero = organisaatio.getPuhelin(Puhelinnumero.TYYPPI_PUHELIN, ytjKielikoodi);
             if(puhelinnumero == null) {
                 puhelinnumero = new Puhelinnumero();
                 if(!initYhteystietoforOrg(puhelinnumero, organisaatio, ytjKielikoodi, YtjVirhe.YTJVirheKohde.PUHELIN, "ilmoitukset.log.virhe.oid.puhelin")) {
@@ -264,7 +264,7 @@ public class OrganisaatioYtjServiceImpl implements OrganisaatioYtjService {
             updatePuhelin = updatePuhelinFromYTJtoOrganisaatio(ytjOrg, puhelinnumero, forceUpdate);
         }
         if(validateYtjWww(ytjOrg)) {
-            Www www = organisaatio.getWww();
+            Www www = organisaatio.getWww(ytjKielikoodi);
             if(www == null) {
                 www = new Www();
                 if(!initYhteystietoforOrg(www, organisaatio, ytjKielikoodi, YtjVirhe.YTJVirheKohde.WWW, "ilmoitukset.log.virhe.oid.www")) {

--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/model/Organisaatio.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/model/Organisaatio.java
@@ -737,34 +737,36 @@ public class Organisaatio extends OrganisaatioBaseEntity {
         this.tuontiPvm = tuontiPvm;
     }
 
-    public Puhelinnumero getPuhelin(String tyyppi) {
-        if (tyyppi == null) {
-            return null;
-        }
-        for (Yhteystieto yhteystieto : getYhteystiedot()) {
-            if (yhteystieto instanceof Puhelinnumero) {
-                if (tyyppi.equals(((Puhelinnumero) yhteystieto).getTyyppi())) {
-                    return (Puhelinnumero) yhteystieto;
+    public Puhelinnumero getPuhelin(String tyyppi, String kieliKoodi) {
+        if (tyyppi != null && kieliKoodi != null) {
+            for (Yhteystieto yhteystieto : getYhteystiedot()) {
+                if (yhteystieto instanceof Puhelinnumero) {
+                    if (tyyppi.equals(((Puhelinnumero) yhteystieto).getTyyppi())) {
+                        return (Puhelinnumero) yhteystieto;
+                    }
                 }
             }
         }
         return null;
     }
 
-
-    public Www getWww() {
-        for(Yhteystieto yhteystieto : getYhteystiedot()) {
-            if(yhteystieto instanceof Www) {
-                return (Www)yhteystieto;
+    public Www getWww(String kieliKoodi) {
+        if (kieliKoodi != null) {
+            for (Yhteystieto yhteystieto : getYhteystiedot()) {
+                if (yhteystieto instanceof Www && kieliKoodi.equals(yhteystieto.getKieli())) {
+                    return (Www) yhteystieto;
+                }
             }
         }
         return null;
     }
 
-    public Email getEmail() {
-        for (Yhteystieto yhteystieto : getYhteystiedot()) {
-            if (yhteystieto instanceof Email) {
-                return (Email) yhteystieto;
+    public Email getEmail(String kieliKoodi) {
+        if (kieliKoodi != null) {
+            for (Yhteystieto yhteystieto : getYhteystiedot()) {
+                if (yhteystieto instanceof Email && kieliKoodi.equals(yhteystieto.getKieli())) {
+                    return (Email) yhteystieto;
+                }
             }
         }
         return null;

--- a/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioYtjServiceImplTest.java
+++ b/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioYtjServiceImplTest.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
+import static fi.vm.sade.organisaatio.business.impl.OrganisaatioYtjServiceImpl.KIELI_KOODI_FI;
+import static fi.vm.sade.organisaatio.business.impl.OrganisaatioYtjServiceImpl.KIELI_KOODI_SV;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ContextConfiguration(locations = {"classpath:spring/test-context.xml"})
@@ -78,11 +80,11 @@ public class OrganisaatioYtjServiceImplTest extends SecurityAwareTestBase {
         assertThat(org)
                 .extracting(organisaatio -> organisaatio.getNimi().getString("fi"),
                         organisaatio -> organisaatio.getNimi().getString("sv"),
-                        organisaatio -> organisaatio.getPostiosoiteByKieli(OrganisaatioYtjServiceImpl.KIELI_KOODI_SV).getOsoite(),
-                        organisaatio -> organisaatio.getPostiosoiteByKieli(OrganisaatioYtjServiceImpl.KIELI_KOODI_FI).getOsoite(),
-                        organisaatio -> organisaatio.getEmail().getEmail(),
-                        organisaatio -> organisaatio.getWww().getWwwOsoite(),
-                        organisaatio -> organisaatio.getPuhelin(Puhelinnumero.TYYPPI_PUHELIN).getPuhelinnumero(),
+                        organisaatio -> organisaatio.getPostiosoiteByKieli(KIELI_KOODI_SV).getOsoite(),
+                        organisaatio -> organisaatio.getPostiosoiteByKieli(KIELI_KOODI_FI).getOsoite(),
+                        organisaatio -> organisaatio.getEmail(KIELI_KOODI_FI).getEmail(),
+                        organisaatio -> organisaatio.getWww(KIELI_KOODI_FI).getWwwOsoite(),
+                        organisaatio -> organisaatio.getPuhelin(Puhelinnumero.TYYPPI_PUHELIN, KIELI_KOODI_FI).getPuhelinnumero(),
                         Organisaatio::getKielet,
                         organisaatio -> organisaatio.getAlkuPvm().getTime(),
                         Organisaatio::getYtjKieli
@@ -96,7 +98,7 @@ public class OrganisaatioYtjServiceImplTest extends SecurityAwareTestBase {
                         "0100000211",
                         Collections.singleton(OrganisaatioYtjServiceImpl.ORG_KIELI_KOODI_FI),
                         915141600000L,// original 2006-06-29, from YTJ 01.01.1999
-                        OrganisaatioYtjServiceImpl.KIELI_KOODI_FI
+                        KIELI_KOODI_FI
                         );
 
         org = organisaatioDAO.findByOid("1.2.2004.1");
@@ -113,11 +115,11 @@ public class OrganisaatioYtjServiceImplTest extends SecurityAwareTestBase {
         assertThat(org)
                 .extracting(organisaatio -> organisaatio.getNimi().getString("fi"),
                         organisaatio -> organisaatio.getNimi().getString("sv"),
-                        organisaatio -> organisaatio.getPostiosoiteByKieli(OrganisaatioYtjServiceImpl.KIELI_KOODI_SV),
-                        organisaatio -> organisaatio.getPostiosoiteByKieli(OrganisaatioYtjServiceImpl.KIELI_KOODI_FI).getOsoite(),
-                        organisaatio -> organisaatio.getEmail().getEmail(),
-                        organisaatio -> organisaatio.getWww().getWwwOsoite(),
-                        organisaatio -> organisaatio.getPuhelin(Puhelinnumero.TYYPPI_PUHELIN).getPuhelinnumero(),
+                        organisaatio -> organisaatio.getPostiosoiteByKieli(KIELI_KOODI_SV),
+                        organisaatio -> organisaatio.getPostiosoiteByKieli(KIELI_KOODI_FI).getOsoite(),
+                        organisaatio -> organisaatio.getEmail(KIELI_KOODI_FI).getEmail(),
+                        organisaatio -> organisaatio.getWww(KIELI_KOODI_FI).getWwwOsoite(),
+                        organisaatio -> organisaatio.getPuhelin(Puhelinnumero.TYYPPI_PUHELIN, KIELI_KOODI_FI).getPuhelinnumero(),
                         Organisaatio::getKielet,
                         organisaatio -> organisaatio.getAlkuPvm().getTime(),
                         Organisaatio::getYtjKieli
@@ -131,7 +133,7 @@ public class OrganisaatioYtjServiceImplTest extends SecurityAwareTestBase {
                         "12345",
                         Collections.singleton(OrganisaatioYtjServiceImpl.ORG_KIELI_KOODI_FI),
                         1298844000000L,// original 2004-08-08, from YTJ 2011-02-28
-                        OrganisaatioYtjServiceImpl.KIELI_KOODI_FI
+                        KIELI_KOODI_FI
                 );
 
         org = organisaatioDAO.findByOid("1.2.2004.5");
@@ -148,11 +150,11 @@ public class OrganisaatioYtjServiceImplTest extends SecurityAwareTestBase {
         assertThat(org)
                 .extracting(organisaatio -> organisaatio.getNimi().getString("fi"),
                         organisaatio -> organisaatio.getNimi().getString("sv"),
-                        organisaatio -> organisaatio.getPostiosoiteByKieli(OrganisaatioYtjServiceImpl.KIELI_KOODI_SV).getOsoite(),
-                        organisaatio -> organisaatio.getPostiosoiteByKieli(OrganisaatioYtjServiceImpl.KIELI_KOODI_FI).getOsoite(),
-                        organisaatio -> organisaatio.getEmail().getEmail(),
-                        organisaatio -> organisaatio.getWww().getWwwOsoite(),
-                        organisaatio -> organisaatio.getPuhelin(Puhelinnumero.TYYPPI_PUHELIN).getPuhelinnumero(),
+                        organisaatio -> organisaatio.getPostiosoiteByKieli(KIELI_KOODI_SV).getOsoite(),
+                        organisaatio -> organisaatio.getPostiosoiteByKieli(KIELI_KOODI_FI).getOsoite(),
+                        organisaatio -> organisaatio.getEmail(KIELI_KOODI_SV).getEmail(),
+                        organisaatio -> organisaatio.getWww(KIELI_KOODI_SV).getWwwOsoite(),
+                        organisaatio -> organisaatio.getPuhelin(Puhelinnumero.TYYPPI_PUHELIN, KIELI_KOODI_FI).getPuhelinnumero(),
                         Organisaatio::getKielet,
                         organisaatio -> organisaatio.getAlkuPvm().getTime(),
                         Organisaatio::getYtjKieli
@@ -166,7 +168,7 @@ public class OrganisaatioYtjServiceImplTest extends SecurityAwareTestBase {
                         "0100000210",
                         Collections.singleton(OrganisaatioYtjServiceImpl.ORG_KIELI_KOODI_SV),
                         1298844000000L,// original 2006-06-29, from YTJ 2011-02-28
-                        OrganisaatioYtjServiceImpl.KIELI_KOODI_SV
+                        KIELI_KOODI_SV
                 );
     }
 


### PR DESCRIPTION
- Korjaa osan organisaatioiden YTJ-tietojen päivityksessä ei huomioida oikean kielistä tietoa tutkittaessa, ovatko tiedot muuttuneet.