### PR TITLE
Korjaa koodistoon synkronoinnin

### DIFF
--- a/organisaatio-service/pom.xml
+++ b/organisaatio-service/pom.xml
@@ -643,6 +643,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock-jre8</artifactId>
+            <version>2.23.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.powermock</groupId>
             <artifactId>powermock-reflect</artifactId>
             <version>1.4.12</version>

--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioKoodistoClient.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioKoodistoClient.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 import java.util.Date;
+import java.util.Optional;
 import java.util.function.Supplier;
 
 import static fi.vm.sade.organisaatio.config.HttpClientConfiguration.HTTP_CLIENT_KOODISTO;
@@ -70,7 +71,7 @@ public class OrganisaatioKoodistoClient {
     public String get(String uri) throws OrganisaatioKoodistoException {
         return wrapException(() -> httpClient.<String>execute(OphHttpRequest.Builder.get(uri).build())
                 .handleErrorStatus(204).with(json -> { throw new RuntimeException(String.format("Osoite %s palautti 204", uri)); }) // ilman tätä 204 => Optional#empty
-                .handleErrorStatus(500).with(json -> null) // 500 => Koodia ei löydy
+                .handleErrorStatus(500).with(json -> Optional.empty()) // 500 => Koodia ei löydy
                 .expectedStatus(200)
                 .mapWith(identity())
                 .orElse(null)); // 404 => Koodia ei löydy

--- a/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioKoodistoClientTest.java
+++ b/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioKoodistoClientTest.java
@@ -1,0 +1,52 @@
+package fi.vm.sade.organisaatio.business.impl;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ContextConfiguration(locations = {"classpath:spring/test-context.xml"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class OrganisaatioKoodistoClientTest {
+
+    @Autowired
+    private OrganisaatioKoodistoClient client;
+
+    @Rule
+    public WireMockRule wireMockRule = new WireMockRule(wireMockConfig().dynamicPort().dynamicHttpsPort());
+
+    @Test
+    public void getWithStatus200ShouldReturnBody() {
+        stubFor(get(urlEqualTo("/test")).willReturn(aResponse().withStatus(200).withBody("test body")));
+
+        String response = client.get("http://localhost:" + wireMockRule.port() + "/test");
+
+        assertThat(response).isEqualTo("test body");
+    }
+
+    @Test
+    public void getWithStatus404ShouldReturnNull() {
+        stubFor(get(urlEqualTo("/test")).willReturn(aResponse().withStatus(404).withBody("test body")));
+
+        String response = client.get("http://localhost:" + wireMockRule.port() + "/test");
+
+        assertThat(response).isNull();
+    }
+
+    @Test
+    public void getWithStatus500ShouldReturnNull() {
+        stubFor(get(urlEqualTo("/test")).willReturn(aResponse().withStatus(500).withBody("test body")));
+
+        String response = client.get("http://localhost:" + wireMockRule.port() + "/test");
+
+        assertThat(response).isNull();
+    }
+
+}

--- a/organisaatio-service/src/test/resources/spring/test-context.xml
+++ b/organisaatio-service/src/test/resources/spring/test-context.xml
@@ -23,6 +23,12 @@
         <property name="useCodeAsDefaultMessage" value="true"/>
     </bean>
 
+    <bean id="httpClientBuilder" class="fi.vm.sade.javautils.http.OphHttpClient$Builder">
+        <constructor-arg value="organisaatio-test" />
+    </bean>
+
+    <bean id="koodistoHttpClient" class="fi.vm.sade.javautils.http.OphHttpClient" factory-bean="httpClientBuilder" factory-method="build"/>
+
     <import resource="classpath:META-INF/spring/context/service-context.xml"/>
     <import resource="classpath:META-INF/spring/context/dao-context.xml"/>
 </beans>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <daemon>false</daemon>
 
         <!-- UI libraries -->
-        <servlet.version>3.0.1</servlet.version>
+        <servlet.version>3.1.0</servlet.version>
         <google.map.widget.version>0.9.13</google.map.widget.version>
         <swagger.version>1.5.17</swagger.version>
         <frontend-plugin.version>1.5</frontend-plugin.version>


### PR DESCRIPTION
Synkronointi ei toiminut uusille organisaatioille koska koodiston
palauttama virhekoodi 500 käsiteltiin väärin (päätyi poikkeukseen).

KH-266