### PR TITLE
Muuttaa käyttöoikeustarkistusten validointia

### DIFF
--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/model/Organisaatio.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/model/Organisaatio.java
@@ -13,6 +13,7 @@ import javax.validation.constraints.NotNull;
 import java.util.*;
 import java.util.stream.Collectors;
 
+import static fi.vm.sade.organisaatio.service.util.PredicateUtil.not;
 import static java.util.stream.Collectors.toSet;
 
 
@@ -670,6 +671,14 @@ public class Organisaatio extends OrganisaatioBaseEntity {
 
     public void setParentOidPath(String parentOidPath) {
         this.parentOidPath = parentOidPath;
+    }
+
+    public List<String> getParentOidsFromPath() {
+        return Optional.ofNullable(parentOidPath)
+                .map(path -> Arrays.stream(path.split("\\|"))
+                        .filter(not(String::isEmpty))
+                        .collect(Collectors.toList()))
+                .orElse(Collections.emptyList());
     }
 
     public String getParentIdPath() {

--- a/organisaatio-service/src/main/java/fi/vm/sade/security/OidProvider.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/security/OidProvider.java
@@ -1,0 +1,32 @@
+package fi.vm.sade.security;
+
+import fi.vm.sade.organisaatio.dao.OrganisaatioDAO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toList;
+
+@Component
+public class OidProvider {
+
+    private final String rootOrganisaatioOid;
+    private final OrganisaatioDAO organisaatioDAO;
+
+    public OidProvider(@Value("${root.organisaatio.oid}") String rootOrganisaatioOid,
+                       OrganisaatioDAO organisaatioDAO) {
+        this.rootOrganisaatioOid = rootOrganisaatioOid;
+        this.organisaatioDAO = organisaatioDAO;
+    }
+
+    public List<String> getSelfAndParentOids(String organisaatioOid) {
+        Stream<String> parentOids = Optional.ofNullable(organisaatioDAO.findByOid(organisaatioOid))
+                .map(organisaatio -> organisaatio.getParentOidsFromPath().stream())
+                .orElseGet(() -> Stream.of(rootOrganisaatioOid));
+        return Stream.concat(parentOids, Stream.of(organisaatioOid)).collect(toList());
+    }
+
+}

--- a/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/model/OrganisaatioTest.java
+++ b/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/model/OrganisaatioTest.java
@@ -2,6 +2,8 @@ package fi.vm.sade.organisaatio.model;
 
 import org.junit.Test;
 
+import java.util.List;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class OrganisaatioTest {
@@ -54,6 +56,36 @@ public class OrganisaatioTest {
         String parentOid = organisaatio.getParentOid().orElse(null);
 
         assertThat(parentOid).isNull();
+    }
+
+    @Test
+    public void parentOidsFromNullPath() {
+        Organisaatio organisaatio = new Organisaatio();
+        organisaatio.setParentOidPath(null);
+
+        List<String> parentOids = organisaatio.getParentOidsFromPath();
+
+        assertThat(parentOids).isEmpty();
+    }
+
+    @Test
+    public void parentOidsFromEmptyPath() {
+        Organisaatio organisaatio = new Organisaatio();
+        organisaatio.setParentOidPath("");
+
+        List<String> parentOids = organisaatio.getParentOidsFromPath();
+
+        assertThat(parentOids).isEmpty();
+    }
+
+    @Test
+    public void parentOidsFromValidPath() {
+        Organisaatio organisaatio = new Organisaatio();
+        organisaatio.setParentOidPath("|1.2.246.562.10.00000000001|1.2.246.562.10.81269623245|1.2.246.562.10.86638002385|");
+
+        List<String> parentOids = organisaatio.getParentOidsFromPath();
+
+        assertThat(parentOids).containsExactly("1.2.246.562.10.00000000001", "1.2.246.562.10.81269623245", "1.2.246.562.10.86638002385");
     }
 
 }


### PR DESCRIPTION
Käyttöoikeuksien tarkistamiseen tarvitaan organisaation
yläorganisaatioiden oidit jotka on aikaisemmin haettu http:n yli
organisaatiopalvelulta. Nyt organisaatiopalvelu hakee itse oidit
tietokannasta ilman http-pyyntöä.

OH-531