### PR TITLE
Korjaa parentPathien asettamisen organisaatioliitoksessa

### DIFF
--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioBusinessServiceImpl.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioBusinessServiceImpl.java
@@ -14,7 +14,6 @@
  */
 package fi.vm.sade.organisaatio.business.impl;
 
-import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import fi.vm.sade.oid.service.ExceptionMessage;
 import fi.vm.sade.oid.service.OIDService;
@@ -629,6 +628,10 @@ public class OrganisaatioBusinessServiceImpl implements OrganisaatioBusinessServ
     }
 
     private void setParentPath(Organisaatio entity, String parentOid) {
+        setParentPath(entity, parentOid, null);
+    }
+
+    private void setParentPath(Organisaatio entity, String parentOid, OrganisaatioSuhde.OrganisaatioSuhdeTyyppi tyyppi) {
         if (parentOid == null) {
             parentOid = rootOrganisaatioOid;
         }
@@ -636,10 +639,13 @@ public class OrganisaatioBusinessServiceImpl implements OrganisaatioBusinessServ
         StringBuilder parentIdPath = new StringBuilder();
         List<Organisaatio> parents = organisaatioDAO.findParentsTo(parentOid);
         for (Organisaatio curParent : parents) {
+            if (OrganisaatioSuhde.OrganisaatioSuhdeTyyppi.LIITOS.equals(tyyppi) && parentOid.equals(curParent.getOid())) {
+                continue;
+            }
             parentOidPath.append(parentSeparator).append(curParent.getOid());
             parentIdPath.append(parentSeparator).append(curParent.getId());
         }
-        if (!parents.isEmpty()) {
+        if (parentOidPath.length() > 0) {
             parentOidPath.append(parentSeparator);
             parentIdPath.append(parentSeparator);
         }
@@ -994,7 +1000,7 @@ public class OrganisaatioBusinessServiceImpl implements OrganisaatioBusinessServ
             LOG.info("Processing {}", os);
 
             Organisaatio child = os.getChild();
-            setParentPath(child, os.getParent().getOid());
+            setParentPath(child, os.getParent().getOid(), os.getSuhdeTyyppi());
             organisaatioDAO.update(child);
 
             updateChildrenRecursive(child);

--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioBusinessServiceImpl.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioBusinessServiceImpl.java
@@ -628,10 +628,6 @@ public class OrganisaatioBusinessServiceImpl implements OrganisaatioBusinessServ
     }
 
     private void setParentPath(Organisaatio entity, String parentOid) {
-        setParentPath(entity, parentOid, null);
-    }
-
-    private void setParentPath(Organisaatio entity, String parentOid, OrganisaatioSuhde.OrganisaatioSuhdeTyyppi tyyppi) {
         if (parentOid == null) {
             parentOid = rootOrganisaatioOid;
         }
@@ -639,13 +635,10 @@ public class OrganisaatioBusinessServiceImpl implements OrganisaatioBusinessServ
         StringBuilder parentIdPath = new StringBuilder();
         List<Organisaatio> parents = organisaatioDAO.findParentsTo(parentOid);
         for (Organisaatio curParent : parents) {
-            if (OrganisaatioSuhde.OrganisaatioSuhdeTyyppi.LIITOS.equals(tyyppi) && parentOid.equals(curParent.getOid())) {
-                continue;
-            }
             parentOidPath.append(parentSeparator).append(curParent.getOid());
             parentIdPath.append(parentSeparator).append(curParent.getId());
         }
-        if (parentOidPath.length() > 0) {
+        if (!parents.isEmpty()) {
             parentOidPath.append(parentSeparator);
             parentIdPath.append(parentSeparator);
         }
@@ -1000,8 +993,11 @@ public class OrganisaatioBusinessServiceImpl implements OrganisaatioBusinessServ
             LOG.info("Processing {}", os);
 
             Organisaatio child = os.getChild();
-            setParentPath(child, os.getParent().getOid(), os.getSuhdeTyyppi());
-            organisaatioDAO.update(child);
+            // Liitos ei muuta parenttia (kts. Organisaatio#getParent)
+            if (!OrganisaatioSuhde.OrganisaatioSuhdeTyyppi.LIITOS.equals(os.getSuhdeTyyppi())) {
+                setParentPath(child, os.getParent().getOid());
+                organisaatioDAO.update(child);
+            }
 
             updateChildrenRecursive(child);
 

--- a/organisaatio-service/src/main/resources/db/migration/V20191004102619643__fix_parent_path.sql
+++ b/organisaatio-service/src/main/resources/db/migration/V20191004102619643__fix_parent_path.sql
@@ -1,0 +1,24 @@
+WITH RECURSIVE aliorganisaatiot(id, oid, depth, parentoidpath, oid_path, parentidpath, id_path) AS (
+    SELECT id, oid, 0, parentoidpath, ARRAY[oid::TEXT], parentidpath, ARRAY[id]
+    FROM organisaatio o
+    WHERE oid = '1.2.246.562.10.00000000001'
+UNION
+    SELECT o.id, o.oid, ao.depth + 1, o.parentoidpath, ARRAY_APPEND(ao.oid_path, o.oid::TEXT), o.parentidpath, ARRAY_APPEND(ao.id_path, o.id)
+    FROM organisaatio o
+    JOIN organisaatiosuhde os ON os.child_id = o.id
+    JOIN aliorganisaatiot ao ON ao.id = os.parent_id
+    WHERE os.suhdetyyppi <> 'LIITOS'
+      AND os.alkupvm < current_date
+      AND (os.loppupvm is null OR os.loppupvm > current_date)
+)
+UPDATE organisaatio o
+SET parentoidpath = '|' || ARRAY_TO_STRING(ARRAY_REMOVE(ao.oid_path, o.oid::TEXT), '|') || '|',
+    parentidpath = '|' || ARRAY_TO_STRING(ARRAY_REMOVE(ao.id_path, o.id), '|') || '|'
+FROM aliorganisaatiot ao
+WHERE ao.id = o.id
+AND o.oid <> '1.2.246.562.10.00000000001'
+AND (
+    '|' || ARRAY_TO_STRING(ARRAY_REMOVE(ao.oid_path, o.oid::TEXT), '|') || '|' <> o.parentoidpath
+    OR
+    '|' || ARRAY_TO_STRING(ARRAY_REMOVE(ao.id_path, o.id), '|') || '|' <> o.parentidpath
+);

--- a/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioBusinessServiceImplTest.java
+++ b/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioBusinessServiceImplTest.java
@@ -168,7 +168,7 @@ public class OrganisaatioBusinessServiceImplTest extends SecurityAwareTestBase {
     @Transactional
     public void processNewOrganisaatioSuhdeChangesWithLiitos() {
         Organisaatio koulutustoimija = service
-                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("koulutustoimija1", OrganisaatioTyyppi.KOULUTUSTOIMIJA.value(), "koulutustoimija", rootOid), false)
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("koulutustoimija", OrganisaatioTyyppi.KOULUTUSTOIMIJA.value(), "koulutustoimija", rootOid), false)
                 .getOrganisaatio();
         assertThat(koulutustoimija).returns("|" + rootOid + "|", Organisaatio::getParentOidPath);
 
@@ -204,8 +204,57 @@ public class OrganisaatioBusinessServiceImplTest extends SecurityAwareTestBase {
         assertThat(muokatut).extracting(Organisaatio::getOid).contains(oppilaitos1.getOid());
 
         assertThat(organisaatioDAO.findByOid(oppilaitos1.getOid()))
-                .returns(oppilaitos2.getParentOidPath(), Organisaatio::getParentOidPath)
-                .returns(oppilaitos2.getParentIdPath(), Organisaatio::getParentIdPath);
+                .returns(koulutustoimija.getParentOidPath() + koulutustoimija.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(koulutustoimija.getParentIdPath() + koulutustoimija.getId() + "|", Organisaatio::getParentIdPath);
+        assertThat(organisaatioDAO.findByOid(toimipiste1.getOid()))
+                .returns(oppilaitos2.getParentOidPath() + oppilaitos2.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(oppilaitos2.getParentIdPath() + oppilaitos2.getId() + "|", Organisaatio::getParentIdPath);
+    }
+
+    @Test
+    @Transactional
+    public void processNewOrganisaatioSuhdeChangesWithLiitosToAnotherTree() {
+        Organisaatio koulutustoimija1 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("koulutustoimija1", OrganisaatioTyyppi.KOULUTUSTOIMIJA.value(), "koulutustoimija1", rootOid), false)
+                .getOrganisaatio();
+        assertThat(koulutustoimija1).returns("|" + rootOid + "|", Organisaatio::getParentOidPath);
+        Organisaatio oppilaitos1 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("oppilaitos1", OrganisaatioTyyppi.OPPILAITOS.value(), "oppilaitos1", koulutustoimija1.getOid()), false)
+                .getOrganisaatio();
+        assertThat(oppilaitos1)
+                .returns(koulutustoimija1.getParentOidPath() + koulutustoimija1.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(koulutustoimija1.getParentIdPath() + koulutustoimija1.getId() + "|", Organisaatio::getParentIdPath);
+        Organisaatio toimipiste1 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("toimipiste1", OrganisaatioTyyppi.TOIMIPISTE.value(), "toimipiste1", oppilaitos1.getOid()), false)
+                .getOrganisaatio();
+        assertThat(toimipiste1)
+                .returns(oppilaitos1.getParentOidPath() + oppilaitos1.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(oppilaitos1.getParentIdPath() + oppilaitos1.getId() + "|", Organisaatio::getParentIdPath);
+
+        Organisaatio koulutustoimija2 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("koulutustoimija2", OrganisaatioTyyppi.KOULUTUSTOIMIJA.value(), "koulutustoimija2", rootOid), false)
+                .getOrganisaatio();
+        Organisaatio oppilaitos2 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("oppilaitos2", OrganisaatioTyyppi.OPPILAITOS.value(), "oppilaitos2", koulutustoimija2.getOid()), false)
+                .getOrganisaatio();
+        assertThat(oppilaitos2)
+                .returns(koulutustoimija2.getParentOidPath() + koulutustoimija2.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(koulutustoimija2.getParentIdPath() + koulutustoimija2.getId() + "|", Organisaatio::getParentIdPath);
+        Organisaatio toimipiste2 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("toimipiste2", OrganisaatioTyyppi.TOIMIPISTE.value(), "toimipiste2", oppilaitos2.getOid()), false)
+                .getOrganisaatio();
+        assertThat(toimipiste2)
+                .returns(oppilaitos2.getParentOidPath() + oppilaitos2.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(oppilaitos2.getParentIdPath() + oppilaitos2.getId() + "|", Organisaatio::getParentIdPath);
+
+        service.mergeOrganisaatio(oppilaitos1, oppilaitos2, new Date());
+
+        Set<Organisaatio> muokatut = service.processNewOrganisaatioSuhdeChanges();
+        assertThat(muokatut).extracting(Organisaatio::getOid).contains(oppilaitos1.getOid());
+
+        assertThat(organisaatioDAO.findByOid(oppilaitos1.getOid()))
+                .returns(koulutustoimija1.getParentOidPath() + koulutustoimija1.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(koulutustoimija1.getParentIdPath() + koulutustoimija1.getId() + "|", Organisaatio::getParentIdPath);
         assertThat(organisaatioDAO.findByOid(toimipiste1.getOid()))
                 .returns(oppilaitos2.getParentOidPath() + oppilaitos2.getOid() + "|", Organisaatio::getParentOidPath)
                 .returns(oppilaitos2.getParentIdPath() + oppilaitos2.getId() + "|", Organisaatio::getParentIdPath);

--- a/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioBusinessServiceImplTest.java
+++ b/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioBusinessServiceImplTest.java
@@ -126,6 +126,91 @@ public class OrganisaatioBusinessServiceImplTest extends SecurityAwareTestBase {
         checkParentOidPath(org, "1.2.2005.5");
     }
 
+    @Test
+    @Transactional
+    public void processNewOrganisaatioSuhdeChangesWithHistoria() {
+        Organisaatio koulutustoimija1 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("koulutustoimija1", OrganisaatioTyyppi.KOULUTUSTOIMIJA.value(), "koulutustoimija1", rootOid), false)
+                .getOrganisaatio();
+        assertThat(koulutustoimija1).returns("|" + rootOid + "|", Organisaatio::getParentOidPath);
+        Organisaatio koulutustoimija2 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("koulutustoimija2", OrganisaatioTyyppi.KOULUTUSTOIMIJA.value(), "koulutustoimija2", rootOid), false)
+                .getOrganisaatio();
+        assertThat(koulutustoimija2).returns("|" + rootOid + "|", Organisaatio::getParentOidPath);
+
+        Organisaatio oppilaitos = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("oppilaitos", OrganisaatioTyyppi.OPPILAITOS.value(), "oppilaitos", koulutustoimija1.getOid()), false)
+                .getOrganisaatio();
+        assertThat(oppilaitos)
+                .returns(koulutustoimija1.getParentOidPath() + koulutustoimija1.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(koulutustoimija1.getParentIdPath() + koulutustoimija1.getId() + "|", Organisaatio::getParentIdPath);
+        Organisaatio toimipiste = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("toimipiste", OrganisaatioTyyppi.TOIMIPISTE.value(), "toimipiste", oppilaitos.getOid()), false)
+                .getOrganisaatio();
+        assertThat(toimipiste)
+                .returns(oppilaitos.getParentOidPath() + oppilaitos.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(oppilaitos.getParentIdPath() + oppilaitos.getId() + "|", Organisaatio::getParentIdPath);
+
+        service.changeOrganisaatioParent(oppilaitos, koulutustoimija2, new Date());
+
+        Set<Organisaatio> muokatut = service.processNewOrganisaatioSuhdeChanges();
+        assertThat(muokatut).extracting(Organisaatio::getOid).contains(oppilaitos.getOid());
+
+        assertThat(organisaatioDAO.findByOid(oppilaitos.getOid()))
+                .returns(koulutustoimija2.getParentOidPath() + koulutustoimija2.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(koulutustoimija2.getParentIdPath() + koulutustoimija2.getId() + "|", Organisaatio::getParentIdPath);
+        assertThat(organisaatioDAO.findByOid(toimipiste.getOid()))
+                .returns(oppilaitos.getParentOidPath() + oppilaitos.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(oppilaitos.getParentIdPath() + oppilaitos.getId() + "|", Organisaatio::getParentIdPath);
+    }
+
+    @Test
+    @Transactional
+    public void processNewOrganisaatioSuhdeChangesWithLiitos() {
+        Organisaatio koulutustoimija = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("koulutustoimija1", OrganisaatioTyyppi.KOULUTUSTOIMIJA.value(), "koulutustoimija", rootOid), false)
+                .getOrganisaatio();
+        assertThat(koulutustoimija).returns("|" + rootOid + "|", Organisaatio::getParentOidPath);
+
+        Organisaatio oppilaitos1 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("oppilaitos1", OrganisaatioTyyppi.OPPILAITOS.value(), "oppilaitos1", koulutustoimija.getOid()), false)
+                .getOrganisaatio();
+        assertThat(oppilaitos1)
+                .returns(koulutustoimija.getParentOidPath() + koulutustoimija.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(koulutustoimija.getParentIdPath() + koulutustoimija.getId() + "|", Organisaatio::getParentIdPath);
+        Organisaatio toimipiste1 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("toimipiste1", OrganisaatioTyyppi.TOIMIPISTE.value(), "toimipiste1", oppilaitos1.getOid()), false)
+                .getOrganisaatio();
+        assertThat(toimipiste1)
+                .returns(oppilaitos1.getParentOidPath() + oppilaitos1.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(oppilaitos1.getParentIdPath() + oppilaitos1.getId() + "|", Organisaatio::getParentIdPath);
+
+        Organisaatio oppilaitos2 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("oppilaitos2", OrganisaatioTyyppi.OPPILAITOS.value(), "oppilaitos2", koulutustoimija.getOid()), false)
+                .getOrganisaatio();
+        assertThat(oppilaitos2)
+                .returns(koulutustoimija.getParentOidPath() + koulutustoimija.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(koulutustoimija.getParentIdPath() + koulutustoimija.getId() + "|", Organisaatio::getParentIdPath);
+        Organisaatio toimipiste2 = service
+                .save(OrganisaatioRDTOTestUtil.createOrganisaatio("toimipiste2", OrganisaatioTyyppi.TOIMIPISTE.value(), "toimipiste2", oppilaitos2.getOid()), false)
+                .getOrganisaatio();
+        assertThat(toimipiste2)
+                .returns(oppilaitos2.getParentOidPath() + oppilaitos2.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(oppilaitos2.getParentIdPath() + oppilaitos2.getId() + "|", Organisaatio::getParentIdPath);
+
+        service.mergeOrganisaatio(oppilaitos1, oppilaitos2, new Date());
+
+        Set<Organisaatio> muokatut = service.processNewOrganisaatioSuhdeChanges();
+        assertThat(muokatut).extracting(Organisaatio::getOid).contains(oppilaitos1.getOid());
+
+        assertThat(organisaatioDAO.findByOid(oppilaitos1.getOid()))
+                .returns(oppilaitos2.getParentOidPath(), Organisaatio::getParentOidPath)
+                .returns(oppilaitos2.getParentIdPath(), Organisaatio::getParentIdPath);
+        assertThat(organisaatioDAO.findByOid(toimipiste1.getOid()))
+                .returns(oppilaitos2.getParentOidPath() + oppilaitos2.getOid() + "|", Organisaatio::getParentOidPath)
+                .returns(oppilaitos2.getParentIdPath() + oppilaitos2.getId() + "|", Organisaatio::getParentIdPath);
+    }
+
 
     private Organisaatio checkParentOidPath(Organisaatio parent, String oid) {
         Organisaatio org = organisaatioDAO.findByOid(oid);


### PR DESCRIPTION
Jos organisaatiot liitetään yhteen, passivoidun organisaation parent pitäisi pysyä ennallaan.

OH-543