### PR TITLE
Validoidaan organisaation yhteystiedot.

### DIFF
--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/model/Organisaatio.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/model/Organisaatio.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang.time.DateUtils;
 import org.hibernate.annotations.BatchSize;
 
 import javax.persistence.*;
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -252,12 +253,12 @@ public class Organisaatio extends OrganisaatioBaseEntity {
         this.metadata = metadata;
     }
 
-    public Set<Yhteystieto> getYhteystiedot() {
+    public @Valid Set<Yhteystieto> getYhteystiedot() {
         return Collections.unmodifiableSet(yhteystiedot);
     }
 
 
-    public void setYhteystiedot(Set<Yhteystieto> newYhteystiedot) {
+    public void setYhteystiedot(@Valid Set<Yhteystieto> newYhteystiedot) {
         yhteystiedot = newYhteystiedot;
     }
 

--- a/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/model/OrganisaatioTest.java
+++ b/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/model/OrganisaatioTest.java
@@ -2,6 +2,8 @@ package fi.vm.sade.organisaatio.model;
 
 import org.junit.Test;
 
+import javax.validation.Validation;
+import javax.validation.Validator;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -86,6 +88,16 @@ public class OrganisaatioTest {
         List<String> parentOids = organisaatio.getParentOidsFromPath();
 
         assertThat(parentOids).containsExactly("1.2.246.562.10.00000000001", "1.2.246.562.10.81269623245", "1.2.246.562.10.86638002385");
+    }
+
+    @Test
+    public void validatesYhteystiedot() {
+        Organisaatio organisaatio = new Organisaatio();
+        Puhelinnumero puhelinnumero = new Puhelinnumero("", Puhelinnumero.TYYPPI_PUHELIN, null);
+        organisaatio.setOid("1.23.456");
+        organisaatio.addYhteystieto(puhelinnumero);
+        Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
+        assertThat(validator.validate(organisaatio)).isNotEmpty();
     }
 
 }


### PR DESCRIPTION
Manuaalinen validointi ei ilman @Valid -annotaatiota
tarkista yhteystietojen sisältöä. Lisätty annotaatio,
sekä testikeissi.