### PR TITLE
Korjattu organisaatioDAO.findModifiedSince() -kutsut.

### DIFF
--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/resource/impl/v2/OrganisaatioResourceImplV2.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/resource/impl/v2/OrganisaatioResourceImplV2.java
@@ -465,7 +465,8 @@ public class OrganisaatioResourceImplV2 implements OrganisaatioResourceV2 {
         LOG.debug("haeMuutetut: " + lastModifiedSince.toString());
         long qstarted = System.currentTimeMillis();
 
-        List<Organisaatio> organisaatiot = organisaatioDAO.findModifiedSince(permissionChecker.isReadAccessToAll() ? null : false, lastModifiedSince.getValue());
+        List<Organisaatio> organisaatiot = organisaatioDAO.findModifiedSince(
+                !permissionChecker.isReadAccessToAll(), lastModifiedSince.getValue());
 
         LOG.debug("Muutettujen haku {} ms", System.currentTimeMillis() - qstarted);
         long qstarted2 = System.currentTimeMillis();
@@ -498,7 +499,8 @@ public class OrganisaatioResourceImplV2 implements OrganisaatioResourceV2 {
         Preconditions.checkNotNull(lastModifiedSince);
         LOG.debug("haeMuutettujenOid: " + lastModifiedSince.toString());
 
-        List<Organisaatio> organisaatiot = organisaatioDAO.findModifiedSince(permissionChecker.isReadAccessToAll() ? null : false, lastModifiedSince.getValue());
+        List<Organisaatio> organisaatiot = organisaatioDAO.findModifiedSince(
+                !permissionChecker.isReadAccessToAll(), lastModifiedSince.getValue());
 
         List<String> oids = new ArrayList<>();
         for (Organisaatio org : organisaatiot) {

--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/resource/impl/v3/OrganisaatioResourceImplV3.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/resource/impl/v3/OrganisaatioResourceImplV3.java
@@ -237,7 +237,8 @@ public class OrganisaatioResourceImplV3 implements OrganisaatioResourceV3 {
         LOG.debug("haeMuutetut: " + lastModifiedSince.toString());
         long qstarted = System.currentTimeMillis();
 
-        List<Organisaatio> organisaatiot = organisaatioDAO.findModifiedSince(permissionChecker.isReadAccessToAll() ? null : false, lastModifiedSince.getValue());
+        List<Organisaatio> organisaatiot = organisaatioDAO.findModifiedSince(
+                !permissionChecker.isReadAccessToAll(), lastModifiedSince.getValue());
 
         LOG.debug("Muutettujen haku {} ms", System.currentTimeMillis() - qstarted);
         long qstarted2 = System.currentTimeMillis();


### PR DESCRIPTION
Näköjään DAO-metskua kutsutaan myös suoraan.