### PR TITLE
OH-637 HikariCP leak detection

### DIFF
--- a/organisaatio-service/src/main/resources/META-INF/spring/context/dao-context.xml
+++ b/organisaatio-service/src/main/resources/META-INF/spring/context/dao-context.xml
@@ -63,6 +63,7 @@
         <property name="maximumPoolSize" value="${organisaatio-service.postgresql.maxactive}" />
         <property name="connectionTimeout" value="${organisaatio-service.postgresql.maxwait}" />
         <property name="maxLifetime" value="${organisaatio-service.postgresql.maxlifetimemillis}"/>
+        <property name="leakDetectionThreshold" value="${organisaatio-service.hikaricp.leakDetectionThreshold:0}"/>
 
         <property name="dataSourceProperties">
             <props>

--- a/src/main/resources/oph-configuration/organisaatio.properties.template
+++ b/src/main/resources/oph-configuration/organisaatio.properties.template
@@ -37,7 +37,7 @@ organisaatio-service.postgresql.password={{host_postgresql_organisaatio_app_pass
 organisaatio-service.postgresql.maxactive={{host_postgresql_organisaatio_max_active}}
 organisaatio-service.postgresql.maxwait={{host_postgresql_organisaatio_max_wait}}
 organisaatio-service.postgresql.maxlifetimemillis=60000
-organisaatio-service.hikaricp.leakDetectionThreshold={{organisaatio_hikaricp_leak_detection_threshold | default 0}}
+organisaatio-service.hikaricp.leakDetectionThreshold={{organisaatio_hikaricp_leak_detection_threshold | default(0)}}
 
 # Oletusarvoja
 activemq.queue.name.log.error=Sade.Log_Error

--- a/src/main/resources/oph-configuration/organisaatio.properties.template
+++ b/src/main/resources/oph-configuration/organisaatio.properties.template
@@ -37,6 +37,7 @@ organisaatio-service.postgresql.password={{host_postgresql_organisaatio_app_pass
 organisaatio-service.postgresql.maxactive={{host_postgresql_organisaatio_max_active}}
 organisaatio-service.postgresql.maxwait={{host_postgresql_organisaatio_max_wait}}
 organisaatio-service.postgresql.maxlifetimemillis=60000
+organisaatio-service.hikaricp.leakDetectionThreshold={{organisaatio_hikaricp_leak_detection_threshold | default 0}}
 
 # Oletusarvoja
 activemq.queue.name.log.error=Sade.Log_Error


### PR DESCRIPTION
Mahdollistaa HikariCP:n leak detectionin käyttöönoton ympäristökohtaisesti määrittelemällä sen opintopolku.yml:iin muuttujan `organisaatio_hikaricp_leak_detection_threshold` (aika millisekunneissa, joka laukaisee connection leak -varoituksen).