### PR TITLE
OH-636 Asetetaan organisaation päivitysaikaileima.

### DIFF
--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioBusinessServiceImpl.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/business/impl/OrganisaatioBusinessServiceImpl.java
@@ -742,7 +742,7 @@ public class OrganisaatioBusinessServiceImpl implements OrganisaatioBusinessServ
                                 throw new OrganisaatioResourceException(Response.Status.INTERNAL_SERVER_ERROR, t.getMessage(), "error.setting.updater");
                             }
                         }
-                        child.setPaivitysPvm(new Date());
+                        // update päivittää aikaleiman
                         organisaatioDAO.update(child);
                         LOG.debug("Name[" + key + "] updated to \"" + childnimi.getString(key) + "\".");
                     } else {
@@ -1161,8 +1161,6 @@ public class OrganisaatioBusinessServiceImpl implements OrganisaatioBusinessServ
         // Päivitetään organisaation nimi
         organisaatio.setNimi(nimiEntity.getNimi());
 
-        organisaatio.setPaivitysPvm(new Date());
-
         LOG.info("updating " + organisaatio);
         try {
             // Päivitetään nimi
@@ -1188,7 +1186,7 @@ public class OrganisaatioBusinessServiceImpl implements OrganisaatioBusinessServ
             Map<String, String> oldName;
             oldName = new HashMap<>(organisaatio.getNimi().getValues());
 
-            LOG.info("Orgnisaation nimen update tarve: " + organisaatio);
+            LOG.info("Organisaation nimen update tarve: " + organisaatio);
 
             // Päiviteään organisaatiolle nimihistorian current nimi
             organisaatio = this.updateCurrentNimiToOrganisaatio(organisaatio);

--- a/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/model/Organisaatio.java
+++ b/organisaatio-service/src/main/java/fi/vm/sade/organisaatio/model/Organisaatio.java
@@ -8,6 +8,7 @@ import fi.vm.sade.security.xssfilter.FilterXss;
 import fi.vm.sade.security.xssfilter.XssFilterListener;
 import org.apache.commons.lang.time.DateUtils;
 import org.hibernate.annotations.BatchSize;
+import org.hibernate.annotations.UpdateTimestamp;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotNull;
@@ -221,6 +222,7 @@ public class Organisaatio extends OrganisaatioBaseEntity {
 
     // OVT-7684
     @Temporal(TemporalType.TIMESTAMP)
+    @UpdateTimestamp
     private Date paivitysPvm;
 
     // OVT-7684

--- a/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/dao/OrganisaatioDAOImplTest.java
+++ b/organisaatio-service/src/test/java/fi/vm/sade/organisaatio/dao/OrganisaatioDAOImplTest.java
@@ -191,14 +191,18 @@ public class OrganisaatioDAOImplTest {
 
     @Test
     public void findModifedSinceLimitsByModificationTime() {
-        Date now = new Date();
         Organisaatio a = createOrganisaatio("A", null, false, null, null);
-        a.setPaivitysPvm(new Date(0L));
         organisaatioDAO.update(a);
+        Date before = new Date();
+        try {
+            Thread.sleep(100L);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
         Organisaatio b = createOrganisaatio("B", null, false, null, null);
-        b.setPaivitysPvm((new Date(now.getTime() + 100)));
         organisaatioDAO.update(b);
-        List<Organisaatio> tulokset = organisaatioDAO.findModifiedSince(false, now);
+        List<Organisaatio> tulokset = organisaatioDAO.findModifiedSince(false, before);
         assertThat(tulokset.size()).isEqualTo(1);
         assertThat(tulokset.get(0).getOid()).isEqualTo(b.getOid());
     }


### PR DESCRIPTION
Aikaisemmin monissa tapauksissa aikaleimaa ei päivitetty,
lisätty Hibernaten @UpdateTimestamp annotaatio. Joissakin
tapauksissa asetetaan vielä manuaalisesti, koska vain save/update
aiheuttaa aikaleiman päivityksen.