### PR TITLE
Muutettu siirtomodaalia niin että listauksissa näytetään nimen lisäks…

### DIFF
--- a/organisaatio-ui/cypress/integration/organisaatio_liitos_spec.js
+++ b/organisaatio-ui/cypress/integration/organisaatio_liitos_spec.js
@@ -49,7 +49,11 @@ describe('Organisaatioyhdistys', () => {
                 cy.intercept('GET', `${PUBLIC_API_CONTEXT}/hae*`).as('getParents');
                 cy.clickButton('LOMAKE_YHDISTA_ORGANISAATIO');
                 cy.wait(['@getParents'], { timeout: 10000 });
-                cy.selectFromList('ORGANISAATIO_YHDISTYS_TOINEN_ORGANISAATIO', child3.body.organisaatio.oid, 'CHILD');
+                cy.selectFromList(
+                    'ORGANISAATIO_YHDISTYS_TOINEN_ORGANISAATIO',
+                    child3.body.organisaatio.ytunnus,
+                    'CHILD'
+                );
 
                 cy.intercept('PUT', `${PUBLIC_API_CONTEXT}/${child2.body.organisaatio.oid}/organisaatiosuhde/*`).as(
                     'merge'

--- a/organisaatio-ui/cypress/integration/organisaatio_new_from_ytj_spec.js
+++ b/organisaatio-ui/cypress/integration/organisaatio_new_from_ytj_spec.js
@@ -6,7 +6,7 @@ beforeEach(() => {
     cy.deleteByYTunnus(Y_TUNNUS);
 });
 describe('New organisaatio from YTJ', () => {
-    it.only('shows UUDEN_TOIMIJAN_LISAAMINEN', () => {
+    it('shows UUDEN_TOIMIJAN_LISAAMINEN', () => {
         cy.visit(`${BASE_PATH}/organisaatiot`);
         cy.get('button').contains('LISAA_UUSI_TOIMIJA').click();
         expect(cy.get('h1').value).to.contain.valueOf('UUDEN_TOIMIJAN_LISAAMINEN');

--- a/organisaatio-ui/cypress/integration/organisaatio_siirto_spec.js
+++ b/organisaatio-ui/cypress/integration/organisaatio_siirto_spec.js
@@ -33,7 +33,7 @@ describe('Organisaatiosiirto', () => {
                 );
                 cy.selectFromList(
                     'ORGANISAATIO_SIIRTO_TOINEN_ORGANISAATIO',
-                    parentOrganisaatio3.body.organisaatio.oid,
+                    parentOrganisaatio3.body.organisaatio.ytunnus,
                     'PARENT'
                 );
                 cy.intercept('PUT', `${PUBLIC_API_CONTEXT}/${child.body.organisaatio.oid}/organisaatiosuhde/*`).as(

--- a/organisaatio-ui/src/components/Modaalit/ToimipisteenYhdistys/LiitaOrganisaatio.tsx
+++ b/organisaatio-ui/src/components/Modaalit/ToimipisteenYhdistys/LiitaOrganisaatio.tsx
@@ -29,7 +29,12 @@ export function LiitaOrganisaatio({
 }) {
     const { i18n } = useContext(LanguageContext);
     const [confirmationModaaliAuki, setConfirmationModaaliAuki] = useState<boolean>(false);
-    const { oid, currentNimi } = organisaatioBase;
+    const { currentNimi, apiOrganisaatio, oid } = organisaatioBase;
+    const fromIdentifier = apiOrganisaatio.ytunnus || apiOrganisaatio.oppilaitosKoodi || oid;
+    const toIdentifier =
+        liitaOrganisaatioon.newParent?.ytunnus ||
+        liitaOrganisaatioon.newParent?.oppilaitosKoodi ||
+        liitaOrganisaatioon.newParent?.oid;
     return (
         <>
             {!confirmationModaaliAuki && (
@@ -60,13 +65,12 @@ export function LiitaOrganisaatio({
                     replacements={[
                         {
                             key: 'from',
-                            value: `${i18n.translateNimi(currentNimi?.nimi)} (${oid})`,
+                            value: `${i18n.translateNimi(currentNimi?.nimi)} (${fromIdentifier})
+                            }`,
                         },
                         {
                             key: 'to',
-                            value: `${i18n.translateNimi(liitaOrganisaatioon.newParent?.nimi)} (${
-                                liitaOrganisaatioon.newParent?.oid || ''
-                            })`,
+                            value: `${i18n.translateNimi(liitaOrganisaatioon.newParent?.nimi)} (${toIdentifier})`,
                         },
                     ]}
                     tallennaCallback={() => {

--- a/organisaatio-ui/src/components/Taulukot/OrganisaatioHakuTaulukko/Hakufiltterit.tsx
+++ b/organisaatio-ui/src/components/Taulukot/OrganisaatioHakuTaulukko/Hakufiltterit.tsx
@@ -97,7 +97,12 @@ export function Hakufiltterit({ setOrganisaatiot, setLoading, filterResults }: H
                         {i18n.translate('TAULUKKO_CHECKBOX_OMAT_ORGANISAATIOT')}
                     </Checkbox>
                 </div>
-                <a href={LISATIEDOT_EXTERNAL_URI} className={styles.LisatiedotLinkki}>
+                <a
+                    href={LISATIEDOT_EXTERNAL_URI}
+                    target={'_blank'}
+                    rel={'noreferrer'}
+                    className={styles.LisatiedotLinkki}
+                >
                     ?
                 </a>
             </div>

--- a/organisaatio-ui/src/tools/organisaatio.ts
+++ b/organisaatio-ui/src/tools/organisaatio.ts
@@ -66,7 +66,7 @@ export const mapOrganisaatioToSelect = (o: ApiOrganisaatio | undefined, language
     if (o)
         return {
             value: `${o.oid}`,
-            label: `${o.nimi[language]} ${o.oid}`,
+            label: `${o.nimi[language]} (${o.ytunnus || o.oppilaitosKoodi})`,
         };
     else return { value: '', label: '' };
 };

--- a/organisaatio-ui/src/tools/organisaatio.ts
+++ b/organisaatio-ui/src/tools/organisaatio.ts
@@ -66,7 +66,7 @@ export const mapOrganisaatioToSelect = (o: ApiOrganisaatio | undefined, language
     if (o)
         return {
             value: `${o.oid}`,
-            label: `${o.nimi[language]} (${o.ytunnus || o.oppilaitosKoodi})`,
+            label: `${o.nimi[language]} (${o.ytunnus || o.oppilaitosKoodi || o.oid})`,
         };
     else return { value: '', label: '' };
 };


### PR DESCRIPTION
…i lisätieto seuraavassa tärkeysjärjestyksessä: y-tunnus, oppilaitosKoodi, oid

Muutettu myös organisaatiotaulukon infonapin linkki avautumaan uuteen välilehteen.